### PR TITLE
Alma9 and dirac 8.0.53

### DIFF
--- a/dirac/Dockerfile
+++ b/dirac/Dockerfile
@@ -1,12 +1,12 @@
-FROM diracgrid/cc7-dirac
+FROM cern/alma9-base
 
 LABEL org.opencontainers.image.source=https://github.com/xenon-middleware/xenon-docker-images
 LABEL org.opencontainers.image.documentation=https://github.com/xenon-middleware/xenon-docker-images/blob/dirac/dirac/README.md
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-ARG dirac_version=8.0.49
-ARG dirac_pilot_version=v8r0p49
-ARG diracos_version=2.42
+ARG dirac_version=8.0.53
+ARG dirac_pilot_version=v8r0p53
+ARG diracos_version=2.43
 
 # Use BUILDKIT_SANDBOX_HOSTNAME to force hostname
 # see https://docs.docker.com/engine/reference/builder/#buildkit-built-in-build-args
@@ -120,9 +120,11 @@ RUN mkdir -p /cvmfs/dirac.egi.eu/dirac/${dirac_pilot_version} && \
 
 COPY --chown=diracuser:diracuser dirac.client.cfg /home/diracuser/dirac.cfg
 
-RUN yum install -y myproxy myproxy-server myproxy-admin 
-RUN chown dirac:dirac /var/lib/myproxy/
+# docker run -ti --rm --privileged cern/alma9-base:latest bash
+# RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm 
+# RUN yum install -y https://github.com/apptainer/apptainer/releases/download/v1.3.4/apptainer-1.3.4-1.x86_64.rpm
+# RUN yum install -y https://github.com/apptainer/apptainer/releases/download/v1.3.4/apptainer-suid-1.3.4-1.x86_64.rpm
 
-COPY myproxy-server.config /etc/myproxy-server.config
+# RUN apptainer run docker://alpine cat /etc/os-release
 
 CMD ["/bin/entrypoint.sh"]

--- a/dirac/README.md
+++ b/dirac/README.md
@@ -13,7 +13,7 @@ and integration test scripts.
 Run image from https://github.com/xenon-middleware/xenon-docker-images/pkgs/container/dirac with:
 
 ```shell
-docker run --privileged --hostname dirac-tuto ghcr.io/xenon-middleware/dirac:8.0.49
+docker run --privileged --hostname dirac-tuto ghcr.io/xenon-middleware/dirac:8.0.53
 ```
 The `--privileged` flag is required to run apptainer containers inside Docker container.
 
@@ -56,7 +56,7 @@ This can be done with `docker-compose` see [../diracclient](diracclient/README.m
 ## Build
 
 ```shell
-docker build -t ghcr.io/xenon-middleware/dirac:8.0.49 --progress plain \
+docker build -t ghcr.io/xenon-middleware/dirac:8.0.53 --progress plain \
   --build-arg BUILDKIT_SANDBOX_HOSTNAME=dirac-tuto .
 ```
 During build need to interact with services which require host certificates. 
@@ -68,8 +68,8 @@ The `--progress plain` makes it possible to see all the output logs.
 Make sure to [configure Docker to be able to push to GitHub container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
 
 ```shell
-docker push ghcr.io/xenon-middleware/dirac:8.0.49
-docker tag ghcr.io/xenon-middleware/dirac:8.0.49 ghcr.io/xenon-middleware/dirac:latest
+docker push ghcr.io/xenon-middleware/dirac:8.0.53
+docker tag ghcr.io/xenon-middleware/dirac:8.0.53 ghcr.io/xenon-middleware/dirac:latest
 docker push ghcr.io/xenon-middleware/dirac:latest
 ```
 

--- a/dirac/entrypoint.sh
+++ b/dirac/entrypoint.sh
@@ -2,5 +2,4 @@
 
 mariadbd-safe &
 /usr/sbin/sshd -De &
-su -c "/usr/sbin/myproxy-server" dirac
 /opt/dirac/sbin/runsvdir-start


### PR DESCRIPTION
Fails during build with
```
------
 > [18/22] RUN nohup bash -c '/bin/entrypoint.sh &' &&     ln -s /var/lib/mysql/mysql.sock /tmp/mysql.sock &&     su dirac -c './install_site.sh -v ${dirac_version} install.cfg && ./post_install.sh ${dirac_pilot_version}':
55.98 2024-10-09 10:19:35 UTC dirac-setup-site [130586465075648] DEBUG: Trying to connect to: dips://dirac-tuto:9135/Configuration/Server
55.98 2024-10-09 10:19:35 UTC dirac-setup-site [130586465075648] WARN: Issue getting socket: <DIRAC.Core.DISET.private.Transports.M2SSLTransport.SSLTransport object at 0x76c484cd1c50> : ('dips', 'dirac-tuto', 9135, 'Configuration/Server') : [Errno 111] Connection refused:ConnectionRefusedError(111, 'Connection refused')
55.98 2024-10-09 10:19:35 UTC dirac-setup-site [130586465075648] INFO: Retry connection : 2 to dips://dirac-tuto:9135/Configuration/Server
55.98 2024-10-09 10:19:35 UTC dirac-setup-site [130586465075648] INFO: Waiting 2.000000 seconds before retry all service(s)
57.98 2024-10-09 10:19:37 UTC dirac-setup-site [130586465075648] DEBUG: Already given a valid url dips://dirac-tuto:9135/Configuration/Server
57.98 2024-10-09 10:19:37 UTC dirac-setup-site [130586465075648] DEBUG: Trying to connect to: dips://dirac-tuto:9135/Configuration/Server
57.98 2024-10-09 10:19:37 UTC dirac-setup-site [130586465075648] WARN: Issue getting socket: <DIRAC.Core.DISET.private.Transports.M2SSLTransport.SSLTransport object at 0x76c484cc6910> : ('dips', 'dirac-tuto', 9135, 'Configuration/Server') : [Errno 111] Connection refused:ConnectionRefusedError(111, 'Connection refused')
57.98 2024-10-09 10:19:37 UTC dirac-setup-site [130586465075648] WARN: Can't update from server Error while updating from dips://dirac-tuto:9135/Configuration/Server: [Errno 111] Connection refused:ConnectionRefusedError(111, 'Connection refused')
57.98 ERROR: Reason(s):
57.98   [Errno 111] Connection refused:ConnectionRefusedError(111, 'Connection refused')
------
Dockerfile:83
--------------------
  82 |     # In tutorial the setup is configured as diracuser user, but here we use dirac user, so not to have diracos installed twice.
  83 | >>> RUN nohup bash -c '/bin/entrypoint.sh &' && \
  84 | >>>     ln -s /var/lib/mysql/mysql.sock /tmp/mysql.sock && \
  85 | >>>     su dirac -c './install_site.sh -v ${dirac_version} install.cfg && ./post_install.sh ${dirac_pilot_version}'
  86 |
--------------------
ERROR: failed to solve: process "/bin/sh -c nohup bash -c '/bin/entrypoint.sh &' &&     ln -s /var/lib/mysql/mysql.sock /tmp/mysql.sock &&     su dirac -c './install_site.sh -v ${dirac_version} install.cfg && ./post_install.sh ${dirac_pilot_version}'" did not complete successfully: exit code: 255
```